### PR TITLE
Allow minor mobiledoc versions 0.2.X, 0.3.X

### DIFF
--- a/lib/mobiledoc/renderers/0.2.rb
+++ b/lib/mobiledoc/renderers/0.2.rb
@@ -6,7 +6,7 @@ require "mobiledoc/error"
 
 module Mobiledoc
   class Renderer_0_2
-    MOBILEDOC_VERSION = '0.2.0'
+    MOBILEDOC_VERSION = /[0][.][2][.].$/
 
     include Mobiledoc::Utils::SectionTypes
     include Mobiledoc::Utils::TagNames
@@ -27,7 +27,7 @@ module Mobiledoc
     end
 
     def validate_version(version)
-      if version != self.class::MOBILEDOC_VERSION
+      if (self.class::MOBILEDOC_VERSION =~ version).nil?
         raise Mobiledoc::Error.new(%Q[Unexpected Mobiledoc version "#{version}"]);
       end
     end

--- a/lib/mobiledoc/renderers/0.3.rb
+++ b/lib/mobiledoc/renderers/0.3.rb
@@ -4,7 +4,7 @@ require "mobiledoc/error"
 
 module Mobiledoc
   class Renderer_0_3 < Renderer_0_2
-    MOBILEDOC_VERSION = '0.3.0'
+    MOBILEDOC_VERSION = /[0][.][3][.].$/
 
     include Mobiledoc::Utils::MarkerTypes
 

--- a/lib/mobiledoc_html_renderer.rb
+++ b/lib/mobiledoc_html_renderer.rb
@@ -66,9 +66,9 @@ module Mobiledoc
       version = mobiledoc['version']
 
       case version
-      when '0.2.0', nil
+      when Renderer_0_2::MOBILEDOC_VERSION
         Renderer_0_2.new(mobiledoc, state).render
-      when '0.3.0', nil
+      when Renderer_0_3::MOBILEDOC_VERSION
         Renderer_0_3.new(mobiledoc, state).render
       else
         raise Mobiledoc::Error.new(%Q[Unexpected Mobiledoc version "#{version}"])


### PR DESCRIPTION
Change `MOBILEDOC_VERSION` to regex to allow for minor versions of mobile doc